### PR TITLE
Fix - PKPaymentButton importing issue on React Native v0.60 and above

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.podspec
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.author       = "Naoufal Kadhom"
   s.platform     = :ios, "7.0"
   s.source       = { :git => giturl + ".git", :tag => version }
-  s.source_files  = "*.{h,m}"
+  s.source_files  = "**/*.{h,m}"
   s.requires_arc = true
 
 

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -8,7 +8,7 @@
     "run:demo": "cd examples/native && yarn run:demo",
     "test": "jest"
   },
-  "repository": "https://github.com/naoufal/react-native-payments",
+  "repository": "https://github.com/fancydevpro/react-native-payments",
   "keywords": [
     "react",
     "react-native",

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fancydevpro/react-native-payments",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",
     "run:ios": "cd examples/native && yarn run:ios",


### PR DESCRIPTION
- Fixed `source_files` in ReactNativePayments.podspec.
- Updated README file.
- Updated the package version to 0.7.2.