### PR TITLE
Fix - check first update event handler and skip if not registered

### DIFF
--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -261,7 +261,7 @@ export default class PaymentRequest {
 
   /**************************************************************/
   _handleFirstUpdate() {
-    return this._firstUpdateFn();
+    return this._firstUpdateFn ? this._firstUpdateFn() : undefined;
   }
   /**************************************************************/
 

--- a/packages/react-native-payments/lib/js/PaymentRequestUpdateEvent.js
+++ b/packages/react-native-payments/lib/js/PaymentRequestUpdateEvent.js
@@ -67,8 +67,11 @@ export default class PaymentRequestUpdateEvent {
 
     /**********************************************************/
     if (this.firstUpdate) {
-      this.firstUpdate = false
-      value = target._handleFirstUpdate()
+      this.firstUpdate = false;
+      const firstUpdatedValue = target._handleFirstUpdate();
+      if (firstUpdatedValue) {
+        value = firstUpdatedValue;
+      }
     }
     /**********************************************************/
 

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fancydevpro/react-native-payments",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",
     "run:ios": "cd examples/native && yarn run:ios",


### PR DESCRIPTION
- Checked the first update event handler and skip if not registered.
- Bumped `@fancydevpro/react-native-payments` package version from 0.7.2 to 0.7.3.